### PR TITLE
Added support for Tianma TM022HDH26

### DIFF
--- a/fbtft_device.c
+++ b/fbtft_device.c
@@ -340,6 +340,26 @@ static struct fbtft_device_display displays[] = {
 			}
 		}
 	}, {
+		.name = "tm022hdh26",
+		.spi = &(struct spi_board_info) {
+			.modalias = "fb_ili9341",
+			.max_speed_hz = 32000000,
+			.mode = SPI_MODE_0,
+			.platform_data = &(struct fbtft_platform_data) {
+				.display = {
+					.buswidth = 8,
+					.backlight = 1,
+				},
+				.bgr = true,
+				.gpios = (const struct fbtft_gpio []) {
+					{ "reset", 25 },
+					{ "dc", 24 },
+					{ "led", 18 },
+					{},
+				},
+			}
+		}
+	}, {
 		.name = "nokia3310",
 		.spi = &(struct spi_board_info) {
 			.modalias = "fb_pcd8544",


### PR DESCRIPTION
Some chinese 2.2" SPI TFTs found on eBay are based on an Tianma TM022HDH26 panel and driven by an ILI9341. Support for the ILI9341 was already present (thanks to @cnvogelg) but the Watterott MI0283QT-9A used a 9bit bus, whereas the chinese stuff uses an 8bit bus with a DC pin.

I just added the definition for that kind of screen in fbtft_device.c.

Tested and working on RPi running Occidentalis 0.2 with kernel version 3.6.11+.

Screen used (eBay link):
http://goo.gl/QUtYY0

Signed-off-by: Kamel Makhloufi melka@blaste.net
