### PR TITLE
modified Makefile to allow out of tree build with custom config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# Optionally, include config file to allow out of tree kernel modules build
 -include .config
 
 # Core module


### PR DESCRIPTION
This change is related to #111. It allows to create custom `config` file and perform out of tree build.
