### PR TITLE
fbtft-core: add the last line into the dirty area

### DIFF
--- a/fbtft-core.c
+++ b/fbtft-core.c
@@ -410,7 +410,7 @@ void fbtft_mkdirty(struct fb_info *info, int y, int height)
 	/* special case, needed ? */
 	if (y == -1) {
 		y = 0;
-		height = info->var.yres - 1;
+		height = info->var.yres;
 	}
 
 	/* Mark display lines/area as dirty */


### PR DESCRIPTION
Hello,

I'm using ILI9341 LCD sub board, and then I found a bug that the fbtft driver could not draw the last one line.
This simple patch is a solution that I tried, if no problems for other devices, please use this.
Thank you :)

yusuke
