### PR TITLE
Corrected the path in README

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ INSTALLATION
   Download kernel sources
 
   From Linux 3.15  
-    cd drivers/video/fbdev/fbtft
+    cd drivers/video/fbdev
     git clone https://github.com/notro/fbtft.git
     
     Add to drivers/video/fbdev/Kconfig:   source "drivers/video/fbdev/fbtft/Kconfig"


### PR DESCRIPTION
Hi,

the subdir fbtft is createt with the git clone command and not available before.

Regards,
Jantek