### PR TITLE
Added support for Beneq EL320.240.36-HB SPI

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,6 +1,7 @@
 menuconfig FB_TFT
 	tristate "Support for small TFT LCD display modules"
-	depends on FB && SPI && GPIOLIB
+	depends on FB && SPI
+	depends on GPIOLIB || COMPILE_TEST
 	select FB_SYS_FILLRECT
 	select FB_SYS_COPYAREA
 	select FB_SYS_IMAGEBLIT
@@ -12,13 +13,19 @@ config FB_TFT_AGM1264K_FL
 	tristate "FB driver for the AGM1264K-FL LCD display"
 	depends on FB_TFT
 	help
-	  Framebuffer support for the AGM1264K-FL LCD display (two Samsung KS0108 compatable chips)
+	  Framebuffer support for the AGM1264K-FL LCD display (two Samsung KS0108 compatible chips)
 
 config FB_TFT_BD663474
 	tristate "FB driver for the BD663474 LCD Controller"
 	depends on FB_TFT
 	help
 	  Generic Framebuffer support for BD663474
+
+config FB_TFT_EL32024036
+	tristate "FB driver for the Beneq EL320.240.36-HB SPI Display"
+	depends on FB_TFT
+	help
+	  Generic Framebuffer support for EL320.240.36-HB
 
 config FB_TFT_HX8340BN
 	tristate "FB driver for the HX8340BN LCD Controller"
@@ -37,6 +44,18 @@ config FB_TFT_HX8353D
 	depends on FB_TFT
 	help
 	  Generic Framebuffer support for HX8353D
+
+config FB_TFT_HX8357D
+	tristate "FB driver for the HX8357D LCD Controller"
+	depends on FB_TFT
+	help
+	  Generic Framebuffer support for HX8357D
+
+config FB_TFT_ILI9163
+	tristate "FB driver for the ILI9163 LCD Controller"
+	depends on FB_TFT
+	help
+	  Generic Framebuffer support for ILI9163
 
 config FB_TFT_ILI9320
 	tristate "FB driver for the ILI9320 LCD Controller"
@@ -128,6 +147,16 @@ config FB_TFT_ST7735R
 	help
 	  Generic Framebuffer support for ST7735R
 
+config FB_TFT_ST7789V
+	tristate "FB driver for the ST7789V LCD Controller"
+	depends on FB_TFT
+	help
+	  This enables generic framebuffer support for the Sitronix ST7789V
+	  display controller. The controller is intended for small color
+	  displays with a resolution of up to 320x240 pixels.
+
+	  Say Y if you have such a display that utilizes this controller.
+
 config FB_TFT_TINYLCD
 	tristate "FB driver for tinylcd.com display"
 	depends on FB_TFT
@@ -139,6 +168,12 @@ config FB_TFT_TLS8204
 	depends on FB_TFT
 	help
 	  Generic Framebuffer support for TLS8204
+
+config FB_TFT_UC1611
+	tristate "FB driver for the UC1611 LCD controller"
+	depends on FB_TFT
+	help
+	  Generic Framebuffer support for UC1611
 
 config FB_TFT_UC1701
 	tristate "FB driver for the UC1701 LCD Controller"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,3 @@
-ifneq ($(KERNELRELEASE),)
-# kbuild part of makefile
-
-# Optionally, include config file to allow out of tree kernel modules build
--include $(src)/.config
-
 # Core module
 obj-$(CONFIG_FB_TFT)             += fbtft.o
 fbtft-y                          += fbtft-core.o fbtft-sysfs.o fbtft-bus.o fbtft-io.o
@@ -11,9 +5,12 @@ fbtft-y                          += fbtft-core.o fbtft-sysfs.o fbtft-bus.o fbtft
 # drivers
 obj-$(CONFIG_FB_TFT_AGM1264K_FL) += fb_agm1264k-fl.o
 obj-$(CONFIG_FB_TFT_BD663474)    += fb_bd663474.o
+obj-$(CONFIG_FB_TFT_EL32024036)  += fb_el32024036.o
 obj-$(CONFIG_FB_TFT_HX8340BN)    += fb_hx8340bn.o
 obj-$(CONFIG_FB_TFT_HX8347D)     += fb_hx8347d.o
 obj-$(CONFIG_FB_TFT_HX8353D)     += fb_hx8353d.o
+obj-$(CONFIG_FB_TFT_HX8357D)     += fb_hx8357d.o
+obj-$(CONFIG_FB_TFT_ILI9163)     += fb_ili9163.o
 obj-$(CONFIG_FB_TFT_ILI9320)     += fb_ili9320.o
 obj-$(CONFIG_FB_TFT_ILI9325)     += fb_ili9325.o
 obj-$(CONFIG_FB_TFT_ILI9340)     += fb_ili9340.o
@@ -29,8 +26,10 @@ obj-$(CONFIG_FB_TFT_SSD1306)     += fb_ssd1306.o
 obj-$(CONFIG_FB_TFT_SSD1331)     += fb_ssd1331.o
 obj-$(CONFIG_FB_TFT_SSD1351)     += fb_ssd1351.o
 obj-$(CONFIG_FB_TFT_ST7735R)     += fb_st7735r.o
+obj-$(CONFIG_FB_TFT_ST7789V)     += fb_st7789v.o
 obj-$(CONFIG_FB_TFT_TINYLCD)     += fb_tinylcd.o
 obj-$(CONFIG_FB_TFT_TLS8204)     += fb_tls8204.o
+obj-$(CONFIG_FB_TFT_UC1611)      += fb_uc1611.o
 obj-$(CONFIG_FB_TFT_UC1701)      += fb_uc1701.o
 obj-$(CONFIG_FB_TFT_UPD161704)   += fb_upd161704.o
 obj-$(CONFIG_FB_TFT_WATTEROTT)   += fb_watterott.o
@@ -38,23 +37,3 @@ obj-$(CONFIG_FB_FLEX)            += flexfb.o
 
 # Device modules
 obj-$(CONFIG_FB_TFT_FBTFT_DEVICE) += fbtft_device.o
-
-else
-# normal makefile
-KDIR ?= /lib/modules/`uname -r`/build
-
-default: .config
-	$(MAKE) -C $(KDIR) M=$$PWD modules
-
-.config:
-	grep config Kconfig | cut -d' ' -f2 | sed 's@^@CONFIG_@; s@$$@=m@' > .config
-
-install:
-	$(MAKE) -C $(KDIR) M=$$PWD modules_install
-
-
-clean:
-	rm -rf *.o *~ core .depend .*.cmd *.ko *.mod.c .tmp_versions \
-	       modules.order Module.symvers
-
-endif

--- a/fb_el32024036.c
+++ b/fb_el32024036.c
@@ -1,0 +1,261 @@
+/*
+ * FB driver for the Beneq EL320.240.36-HB SPI Display
+ *
+ * Based on the HX8347D FB driver
+ * Copyright (C) 2013 Christian Vogelgsang
+ *
+ * Based on driver code found here: https://github.com/watterott/r61505u-Adapter
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/delay.h>
+
+#include "fbtft.h"
+#include "fb_el32024036.h"
+
+#define DRVNAME	"fb_el32024036"
+#define FPS 10
+
+u8 xor = 0;
+u8 sof = 0xff;				// start of frame cmd
+u8 eof = 0x55;				// end of frame cmd
+u8 comPeriodCMD = 0x62;		// period cmd
+u8 comPeriodDATA = 0x7f;	// period data cmd
+u8 clearCMD = 0x11;			// clear screen cmd
+u8 startCMD = 0x01;			// start cmd
+
+void xor_calc(unsigned char c)
+{
+	xor ^= c;
+}
+
+void xor_reset(void)
+{
+	xor = 0;
+}
+
+#if defined(HARDWARE_REV_1)
+static int init_display(struct fbtft_par *par)
+{
+	int ret = 0;
+
+	par->fbtftops.write_vmem = el32024036_write_vmem;
+
+	ret = par->fbtftops.write(par, &clearCMD, 1);
+	if (ret < 0) {
+		dev_err(par->info->device, "display spi write failed and returned: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int el32024036_write_vmem(struct fbtft_par *par, size_t offset, size_t len)
+{
+	u8 *sourceSPI = (u8 *)(par->info->screen_buffer + offset);
+	int ret = 0;
+
+	fbtft_par_dbg(DEBUG_WRITE_VMEM, par, "%s(offset=%zu, len=%zu)\n", __func__, offset, len);
+
+	ret = par->fbtftops.write(par, &startCMD, 1);
+	if (ret < 0) {
+		dev_err(par->info->device, "display spi write failed and returned: %d\n", ret);
+		return ret;
+	}
+
+	ret = par->fbtftops.write(par, sourceSPI, TOTAL_BYTES);
+	if (ret < 0) {
+		dev_err(par->info->device, "display spi write failed and returned: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+#elif defined(HARDWARE_REV_A)
+static int init_display(struct fbtft_par *par)
+{
+    int ret = 0, i = 0;
+
+	par->fbtftops.write_vmem = el32024036_write_vmem;
+
+	xor_reset();
+	xor_calc(comPeriodCMD);
+	xor_calc(comPeriodDATA);
+
+	((u8 *)par->txbuf.buf)[i++] = sof;
+	((u8 *)par->txbuf.buf)[i++] = comPeriodCMD;
+	((u8 *)par->txbuf.buf)[i++] = comPeriodDATA;
+	((u8 *)par->txbuf.buf)[i++] = xor;
+	((u8 *)par->txbuf.buf)[i++] = eof;
+
+	ret = par->fbtftops.write(par, &(((u8 *)par->txbuf.buf)[0]), i);
+	if (ret < 0) {
+		dev_err(par->info->device, "display spi write failed and returned: %d\n", ret);
+		return ret;
+	}
+
+	//mdelay(500);
+
+	i = 0;
+	xor_reset();
+	xor_calc(clearCMD);
+
+	((u8 *)par->txbuf.buf)[i++] = sof;
+	((u8 *)par->txbuf.buf)[i++] = clearCMD;
+	((u8 *)par->txbuf.buf)[i++] = xor;
+	((u8 *)par->txbuf.buf)[i++] = eof;
+
+	ret = par->fbtftops.write(par, &(((u8 *)par->txbuf.buf)[0]), i);
+	if (ret < 0) {
+		dev_err(par->info->device, "display spi write failed and returned: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int el32024036_write_vmem(struct fbtft_par *par, size_t offset, size_t len)
+{
+	u8 *sourceSPI = (u8 *)(par->info->screen_buffer + offset);
+	u8 spibytes = 0, remainderbytes = 0;
+	int ret = 0, xcount = 0, ycount = 0, bcount = 0, remainder = 0, i = 0;
+
+	fbtft_par_dbg(DEBUG_WRITE_VMEM, par, "%s(offset=%zu, len=%zu)\n", __func__, offset, len);
+
+	xor_reset();
+	xor_calc(comPeriodCMD);
+	xor_calc(comPeriodDATA);
+
+	((u8 *)par->txbuf.buf)[i++] = sof;
+	((u8 *)par->txbuf.buf)[i++] = comPeriodCMD;
+	((u8 *)par->txbuf.buf)[i++] = comPeriodDATA;
+	((u8 *)par->txbuf.buf)[i++] = xor;
+	((u8 *)par->txbuf.buf)[i++] = eof;
+
+	ret = par->fbtftops.write(par, &(((u8 *)par->txbuf.buf)[0]), i);
+	if (ret < 0) {
+		dev_err(par->info->device, "display spi write failed and returned: %d\n", ret);
+		return ret;
+	}
+
+	i = 0;
+	xor_reset();
+	xor_calc(startCMD);
+
+	((u8 *)par->txbuf.buf)[i++] = sof;
+	((u8 *)par->txbuf.buf)[i++] = startCMD;
+
+	for (xcount = 0; xcount < 240; xcount++)
+	{
+		for (ycount = 0;;)
+		{
+			spibytes = 0;
+
+			if (ycount == 44) {
+				spibytes = remainderbytes | (*sourceSPI & 0xff) >> 5;
+				remainderbytes = 0;
+				remainderbytes |= (*sourceSPI++ & 0x1f) << 2;
+				((u8 *)par->txbuf.buf)[i++] = spibytes;
+				xor_calc(spibytes);
+				((u8 *)par->txbuf.buf)[i++] = remainderbytes;
+				xor_calc(remainderbytes);
+				bcount = 0;
+				break;
+			}
+
+			switch (bcount) {
+				case 0:
+					spibytes |= (*sourceSPI & 0xff) >> 1;
+					remainderbytes = 0;
+					remainderbytes |= (*sourceSPI++ & 0x01) << 6;
+					bcount = 1;
+					((u8 *)par->txbuf.buf)[i++] = spibytes;
+					xor_calc(spibytes);
+					ycount++;
+					break;
+				case 1:
+				case 2:
+				case 3:
+				case 4:
+				case 5:
+					spibytes = remainderbytes | (*sourceSPI & 0xff) >> (bcount + 1);
+					remainderbytes = 0;
+					remainderbytes |= (*sourceSPI++ & (0xff >> (7-bcount))) << (6 - bcount);
+					bcount++;
+					((u8 *)par->txbuf.buf)[i++] = spibytes;
+					xor_calc(spibytes);
+					ycount++;
+					break;
+				case 6:
+					spibytes = remainderbytes | (*sourceSPI & 0xff) >> 7;
+					remainderbytes = 0;
+					remainderbytes |= (*sourceSPI++ & 0x7f) << 0;
+					bcount = 0;
+					((u8 *)par->txbuf.buf)[i++] = spibytes;
+					xor_calc(spibytes);
+					ycount++;
+					((u8 *)par->txbuf.buf)[i++] = remainderbytes;
+					xor_calc(remainderbytes);
+					ycount++;
+					break;
+			}
+		}
+	}
+
+	((u8 *)par->txbuf.buf)[i++] = xor;
+	((u8 *)par->txbuf.buf)[i++] = eof;
+
+	ret = par->fbtftops.write(par, &(((u8 *)par->txbuf.buf)[0]), TOTAL_BYTES);
+	if (ret < 0) {
+		dev_err(par->info->device, "display spi write failed and returned: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+#endif
+
+static void set_addr_win(struct fbtft_par *par, int xs, int ys, int xe, int ye) { }
+
+static int verify_gpios(struct fbtft_par *par)
+{
+	return 0;
+}
+
+static struct fbtft_display display = {
+	.regwidth = 8,
+	.width = WIDTH,
+	.height = HEIGHT,
+	.bpp = BPP,
+	.fps = FPS,
+	.txbuflen = TOTAL_BYTES,
+	.fbtftops = {
+		.init_display = init_display,
+		.set_addr_win = set_addr_win,
+		.verify_gpios = verify_gpios,
+		.set_var = NULL,
+	},
+};
+
+FBTFT_REGISTER_DRIVER(DRVNAME, "beneq,el32024036", &display);
+
+MODULE_ALIAS("spi:" DRVNAME);
+MODULE_ALIAS("platform:" DRVNAME);
+MODULE_ALIAS("spi:el32024036");
+MODULE_ALIAS("platform:el32024036");
+
+MODULE_DESCRIPTION("FB driver for the Beneq EL320.240.36-HB SPI Display");
+MODULE_AUTHOR("Antonio Jenkins <antonioj@rugged-controls.com>");
+MODULE_LICENSE("GPL");

--- a/fb_el32024036.h
+++ b/fb_el32024036.h
@@ -1,0 +1,51 @@
+/*
+ * FB driver for the Beneq EL320.240.36-HB SPI Display
+ *
+ * Based on the HX8347D FB driver
+ * Copyright (C) 2013 Christian Vogelgsang
+ *
+ * Based on driver code found here: https://github.com/watterott/r61505u-Adapter
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef __EL32024036_H__
+#define __EL32024036_H__
+
+// framebuffer setup for this driver:
+// width = 40
+// height = 240
+// bits per pixel = 1
+//
+// Note:
+// Linux framebuffer should be setup for 40x240, 1 bpp.  Driver code (elsewhere) must deal with turning the 320x240 data
+// into 40x240 and write it to the framebuffer device (this packs all 320 bits into 40 bytes, 320/8 = 40).
+
+//#define HARDWARE_REV_1
+#define HARDWARE_REV_A
+
+#define BPP		1
+#define WIDTH	( 320 / (BPP * 8) ) // framebuffer has 320 bits of data per line packed into 40 bytes
+#define HEIGHT	240
+
+#if defined(HARDWARE_REV_1)
+	#define TOTAL_BYTES	(WIDTH * HEIGHT)
+#elif defined(HARDWARE_REV_A)
+	// extra 6 bytes needed per row due to mark bit in each byte
+	// extra 4 bytes for start_of_frame, cmd, xor and end_of_frame bytes
+	#define TOTAL_BYTES ((WIDTH + 6) * HEIGHT) + 4
+#endif
+
+static int el32024036_write_vmem(struct fbtft_par *par, size_t offset, size_t len);
+static void set_addr_win(struct fbtft_par *par, int xs, int ys, int xe, int ye);
+static int verify_gpios_dc(struct fbtft_par *par);
+
+#endif /* __EL32024036_H__ */

--- a/fbtft_device.c
+++ b/fbtft_device.c
@@ -11,31 +11,26 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#define pr_fmt(fmt) "fbtft_device: " fmt
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/init.h>
 #include <linux/gpio.h>
 #include <linux/spi/spi.h>
+#include <video/mipi_display.h>
 
 #include "fbtft.h"
 
-#define DRVNAME "fbtft_device"
-
 #define MAX_GPIOS 32
 
-struct spi_device *spi_device;
-struct platform_device *p_device;
+static struct spi_device *spi_device;
+static struct platform_device *p_device;
 
 static char *name;
 module_param(name, charp, 0);
-MODULE_PARM_DESC(name, "Devicename (required). " \
-"name=list => list all supported devices.");
+MODULE_PARM_DESC(name, "Devicename (required). name=list => list all supported devices.");
 
 static unsigned rotate;
 module_param(rotate, uint, 0);
@@ -61,8 +56,7 @@ MODULE_PARM_DESC(mode, "SPI mode (override device default)");
 static char *gpios;
 module_param(gpios, charp, 0);
 MODULE_PARM_DESC(gpios,
-"List of gpios. Comma separated with the form: reset:23,dc:24 " \
-"(when overriding the default, all gpios must be specified)");
+"List of gpios. Comma separated with the form: reset:23,dc:24 (when overriding the default, all gpios must be specified)");
 
 static unsigned fps;
 module_param(fps, uint, 0);
@@ -88,8 +82,7 @@ MODULE_PARM_DESC(startbyte, "Sets the Start byte used by some SPI displays.");
 
 static bool custom;
 module_param(custom, bool, 0);
-MODULE_PARM_DESC(custom, "Add a custom display device. " \
-"Use speed= argument to make it a SPI device, else platform_device");
+MODULE_PARM_DESC(custom, "Add a custom display device. Use speed= argument to make it a SPI device, else platform_device");
 
 static unsigned width;
 module_param(width, uint, 0);
@@ -109,7 +102,7 @@ module_param_array(init, int, &init_num, 0);
 MODULE_PARM_DESC(init, "Init sequence, used with the custom argument");
 
 static unsigned long debug;
-module_param(debug, ulong , 0);
+module_param(debug, ulong, 0);
 MODULE_PARM_DESC(debug,
 "level: 0-7 (the remaining 29 bits is for advanced usage)");
 
@@ -117,7 +110,6 @@ static unsigned verbose = 3;
 module_param(verbose, uint, 0);
 MODULE_PARM_DESC(verbose,
 "0 silent, >0 show gpios, >1 show devices, >2 show devices before (default=3)");
-
 
 struct fbtft_device_display {
 	char *name;
@@ -135,44 +127,123 @@ static void adafruit18_green_tab_set_addr_win(struct fbtft_par *par,
 		"02 1c 07 12 37 32 29 2d 29 25 2B 39 00 01 03 10\n" \
 		"03 1d 07 06 2E 2C 29 2D 2E 2E 37 3F 00 00 02 10"
 
+#define CBERRY28_GAMMA \
+		"D0 00 14 15 13 2C 42 43 4E 09 16 14 18 21\n" \
+		"D0 00 14 15 13 0B 43 55 53 0C 17 14 23 20"
+
+static int cberry28_init_sequence[] = {
+	/* turn off sleep mode */
+	-1, MIPI_DCS_EXIT_SLEEP_MODE,
+	-2, 120,
+
+	/* set pixel format to RGB-565 */
+	-1, MIPI_DCS_SET_PIXEL_FORMAT, MIPI_DCS_PIXEL_FMT_16BIT,
+
+	-1, 0xB2, 0x0C, 0x0C, 0x00, 0x33, 0x33,
+
+	/*
+	 * VGH = 13.26V
+	 * VGL = -10.43V
+	 */
+	-1, 0xB7, 0x35,
+
+	/*
+	 * VDV and VRH register values come from command write
+	 * (instead of NVM)
+	 */
+	-1, 0xC2, 0x01, 0xFF,
+
+	/*
+	 * VAP =  4.7V + (VCOM + VCOM offset + 0.5 * VDV)
+	 * VAN = -4.7V + (VCOM + VCOM offset + 0.5 * VDV)
+	 */
+	-1, 0xC3, 0x17,
+
+	/* VDV = 0V */
+	-1, 0xC4, 0x20,
+
+	/* VCOM = 0.675V */
+	-1, 0xBB, 0x17,
+
+	/* VCOM offset = 0V */
+	-1, 0xC5, 0x20,
+
+	/*
+	 * AVDD = 6.8V
+	 * AVCL = -4.8V
+	 * VDS = 2.3V
+	 */
+	-1, 0xD0, 0xA4, 0xA1,
+
+	-1, MIPI_DCS_SET_DISPLAY_ON,
+
+	-3,
+};
+
 static int hy28b_init_sequence[] = {
-	-1,0x00e7,0x0010,-1,0x0000,0x0001,-1,0x0001,0x0100,-1,0x0002,0x0700,
-	-1,0x0003,0x1030,-1,0x0004,0x0000,-1,0x0008,0x0207,-1,0x0009,0x0000,
-	-1,0x000a,0x0000,-1,0x000c,0x0001,-1,0x000d,0x0000,-1,0x000f,0x0000,
-	-1,0x0010,0x0000,-1,0x0011,0x0007,-1,0x0012,0x0000,-1,0x0013,0x0000,
-	-2,50,-1,0x0010,0x1590,-1,0x0011,0x0227,-2,50,-1,0x0012,0x009c,-2,50,
-	-1,0x0013,0x1900,-1,0x0029,0x0023,-1,0x002b,0x000e,-2,50,
-	-1,0x0020,0x0000,-1,0x0021,0x0000,-2,50,-1,0x0050,0x0000,
-	-1,0x0051,0x00ef,-1,0x0052,0x0000,-1,0x0053,0x013f,-1,0x0060,0xa700,
-	-1,0x0061,0x0001,-1,0x006a,0x0000,-1,0x0080,0x0000,-1,0x0081,0x0000,
-	-1,0x0082,0x0000,-1,0x0083,0x0000,-1,0x0084,0x0000,-1,0x0085,0x0000,
-	-1,0x0090,0x0010,-1,0x0092,0x0000,-1,0x0093,0x0003,-1,0x0095,0x0110,
-	-1,0x0097,0x0000,-1,0x0098,0x0000,-1,0x0007,0x0133,-1,0x0020,0x0000,
-	-1,0x0021,0x0000,-2,100,-3 };
+	-1, 0x00e7, 0x0010, -1, 0x0000, 0x0001,
+	-1, 0x0001, 0x0100, -1, 0x0002, 0x0700,
+	-1, 0x0003, 0x1030, -1, 0x0004, 0x0000,
+	-1, 0x0008, 0x0207, -1, 0x0009, 0x0000,
+	-1, 0x000a, 0x0000, -1, 0x000c, 0x0001,
+	-1, 0x000d, 0x0000, -1, 0x000f, 0x0000,
+	-1, 0x0010, 0x0000, -1, 0x0011, 0x0007,
+	-1, 0x0012, 0x0000, -1, 0x0013, 0x0000,
+	-2, 50, -1, 0x0010, 0x1590, -1, 0x0011,
+	0x0227, -2, 50, -1, 0x0012, 0x009c, -2, 50,
+	-1, 0x0013, 0x1900, -1, 0x0029, 0x0023,
+	-1, 0x002b, 0x000e, -2, 50,
+	-1, 0x0020, 0x0000, -1, 0x0021, 0x0000,
+	-2, 50, -1, 0x0050, 0x0000,
+	-1, 0x0051, 0x00ef, -1, 0x0052, 0x0000,
+	-1, 0x0053, 0x013f, -1, 0x0060, 0xa700,
+	-1, 0x0061, 0x0001, -1, 0x006a, 0x0000,
+	-1, 0x0080, 0x0000, -1, 0x0081, 0x0000,
+	-1, 0x0082, 0x0000, -1, 0x0083, 0x0000,
+	-1, 0x0084, 0x0000, -1, 0x0085, 0x0000,
+	-1, 0x0090, 0x0010, -1, 0x0092, 0x0000,
+	-1, 0x0093, 0x0003, -1, 0x0095, 0x0110,
+	-1, 0x0097, 0x0000, -1, 0x0098, 0x0000,
+	-1, 0x0007, 0x0133, -1, 0x0020, 0x0000,
+	-1, 0x0021, 0x0000, -2, 100, -3 };
 
 #define HY28B_GAMMA \
 	"04 1F 4 7 7 0 7 7 6 0\n" \
 	"0F 00 1 7 4 0 0 0 6 7"
 
 static int pitft_init_sequence[] = {
-	-1,0x01,-2,5,-1,0x28,-1,0xEF,0x03,0x80,0x02,-1,0xCF,0x00,0xC1,0x30,
-	-1,0xED,0x64,0x03,0x12,0x81,-1,0xE8,0x85,0x00,0x78,
-	-1,0xCB,0x39,0x2C,0x00,0x34,0x02,-1,0xF7,0x20,-1,0xEA,0x00,0x00,
-	-1,0xC0,0x23,-1,0xC1,0x10,-1,0xC5,0x3e,0x28,-1,0xC7,0x86,-1,0x3A,0x55,
-	-1,0xB1,0x00,0x18,-1,0xB6,0x08,0x82,0x27,-1,0xF2,0x00,-1,0x26,0x01,
-	-1,0xE0,0x0F,0x31,0x2B,0x0C,0x0E,0x08,0x4E,0xF1,0x37,0x07,0x10,0x03,
-	0x0E,0x09,0x00,-1,0xE1,0x00,0x0E,0x14,0x03,0x11,0x07,0x31,0xC1,0x48,
-	0x08,0x0F,0x0C,0x31,0x36,0x0F,-1,0x11,-2,100,-1,0x29,-2,20,-3 };
+	-1, 0x01, -2, 5, -1, 0x28, -1, 0xEF,
+	0x03, 0x80, 0x02, -1, 0xCF, 0x00, 0xC1, 0x30,
+	-1, 0xED, 0x64, 0x03, 0x12, 0x81,
+	-1, 0xE8, 0x85, 0x00, 0x78,
+	-1, 0xCB, 0x39, 0x2C, 0x00, 0x34, 0x02,
+	-1, 0xF7, 0x20, -1, 0xEA, 0x00, 0x00,
+	-1, 0xC0, 0x23, -1, 0xC1, 0x10, -1, 0xC5,
+	0x3e, 0x28, -1, 0xC7, 0x86, -1, 0x3A, 0x55,
+	-1, 0xB1, 0x00, 0x18, -1, 0xB6, 0x08, 0x82,
+	0x27, -1, 0xF2, 0x00, -1, 0x26, 0x01,
+	-1, 0xE0, 0x0F, 0x31, 0x2B, 0x0C, 0x0E, 0x08,
+	0x4E, 0xF1, 0x37, 0x07, 0x10, 0x03,
+	0x0E, 0x09, 0x00, -1, 0xE1, 0x00, 0x0E, 0x14,
+	0x03, 0x11, 0x07, 0x31, 0xC1, 0x48,
+	0x08, 0x0F, 0x0C, 0x31, 0x36, 0x0F, -1,
+	0x11, -2, 100, -1, 0x29, -2, 20, -3 };
 
 static int waveshare32b_init_sequence[] = {
-	-1,0xCB,0x39,0x2C,0x00,0x34,0x02,-1,0xCF,0x00,0xC1,0x30,
-	-1,0xE8,0x85,0x00,0x78,-1,0xEA,0x00,0x00,-1,0xED,0x64,0x03,0x12,0x81,
-	-1,0xF7,0x20,-1,0xC0,0x23,-1,0xC1,0x10,-1,0xC5,0x3e,0x28,-1,0xC7,0x86,
-	-1,0x36,0x28,-1,0x3A,0x55,-1,0xB1,0x00,0x18,-1,0xB6,0x08,0x82,0x27,
-	-1,0xF2,0x00,-1,0x26,0x01,
-	-1,0xE0,0x0F,0x31,0x2B,0x0C,0x0E,0x08,0x4E,0xF1,0x37,0x07,0x10,0x03,0x0E,0x09,0x00,
-	-1,0xE1,0x00,0x0E,0x14,0x03,0x11,0x07,0x31,0xC1,0x48,0x08,0x0F,0x0C,0x31,0x36,0x0F,
-	-1,0x11,-2,120,-1,0x29,-1,0x2c,-3 };
+	-1, 0xCB, 0x39, 0x2C, 0x00, 0x34, 0x02,
+	-1, 0xCF, 0x00, 0xC1, 0x30,
+	-1, 0xE8, 0x85, 0x00, 0x78, -1, 0xEA, 0x00,
+	0x00, -1, 0xED, 0x64, 0x03, 0x12, 0x81,
+	-1, 0xF7, 0x20, -1, 0xC0, 0x23, -1, 0xC1,
+	0x10, -1, 0xC5, 0x3e, 0x28, -1, 0xC7, 0x86,
+	-1, 0x36, 0x28, -1, 0x3A, 0x55, -1, 0xB1, 0x00,
+	0x18, -1, 0xB6, 0x08, 0x82, 0x27,
+	-1, 0xF2, 0x00, -1, 0x26, 0x01,
+	-1, 0xE0, 0x0F, 0x31, 0x2B, 0x0C, 0x0E, 0x08, 0x4E,
+	0xF1, 0x37, 0x07, 0x10, 0x03, 0x0E, 0x09, 0x00,
+	-1, 0xE1, 0x00, 0x0E, 0x14, 0x03, 0x11, 0x07, 0x31,
+	0xC1, 0x48, 0x08, 0x0F, 0x0C, 0x31, 0x36, 0x0F,
+	-1, 0x11, -2, 120, -1, 0x29, -1, 0x2c, -3 };
 
 /* Supported displays in alphabetical order */
 static struct fbtft_device_display displays[] = {
@@ -206,7 +277,7 @@ static struct fbtft_device_display displays[] = {
 				.display = {
 					.buswidth = 8,
 					.backlight = 1,
-					.fbtftops.set_addr_win = \
+					.fbtftops.set_addr_win =
 					    adafruit18_green_tab_set_addr_win,
 				},
 				.bgr = true,
@@ -296,6 +367,27 @@ static struct fbtft_device_display displays[] = {
 			}
 		}
 	}, {
+		.name = "admatec_c-berry28",
+		.spi = &(struct spi_board_info) {
+			.modalias = "fb_st7789v",
+			.max_speed_hz = 48000000,
+			.mode = SPI_MODE_0,
+			.platform_data = &(struct fbtft_platform_data) {
+				.display = {
+					.buswidth = 8,
+					.backlight = 1,
+					.init_sequence = cberry28_init_sequence,
+				},
+				.gpios = (const struct fbtft_gpio []) {
+					{ "reset", 25 },
+					{ "dc", 22 },
+					{ "led", 18 },
+					{},
+				},
+				.gamma = CBERRY28_GAMMA,
+			}
+		}
+	}, {
 		.name = "agm1264k-fl",
 		.pdev = &(struct platform_device) {
 			.name = "fb_agm1264k-fl",
@@ -327,6 +419,22 @@ static struct fbtft_device_display displays[] = {
 				.gpios = (const struct fbtft_gpio []) {
 					{ "reset", 13 },
 					{ "dc", 6 },
+					{},
+				},
+			}
+		}
+	}, {
+		.name = "el32024036",
+		.spi = &(struct spi_board_info) {
+			.modalias = "fb_el32024036",
+			.max_speed_hz = 5000000,
+			.mode = SPI_MODE_0,
+			.bus_num = 2,
+			.platform_data = &(struct fbtft_platform_data) {
+				.display = {
+					.buswidth = 8,
+				},
+				.gpios = (const struct fbtft_gpio []) {
 					{},
 				},
 			}
@@ -369,6 +477,37 @@ static struct fbtft_device_display displays[] = {
 				.gpios = (const struct fbtft_gpio []) {
 					{ "reset", 25 },
 					{ "dc", 24 },
+					{},
+				},
+			}
+		}
+	}, {
+		.name = "ew24ha0",
+		.spi = &(struct spi_board_info) {
+			.modalias = "fb_uc1611",
+			.max_speed_hz = 32000000,
+			.mode = SPI_MODE_3,
+			.platform_data = &(struct fbtft_platform_data) {
+				.display = {
+					.buswidth = 8,
+				},
+				.gpios = (const struct fbtft_gpio []) {
+					{ "dc", 24 },
+					{},
+				},
+			}
+		}
+	}, {
+		.name = "ew24ha0_9bit",
+		.spi = &(struct spi_board_info) {
+			.modalias = "fb_uc1611",
+			.max_speed_hz = 32000000,
+			.mode = SPI_MODE_3,
+			.platform_data = &(struct fbtft_platform_data) {
+				.display = {
+					.buswidth = 9,
+				},
+				.gpios = (const struct fbtft_gpio []) {
 					{},
 				},
 			}
@@ -463,7 +602,7 @@ static struct fbtft_device_display displays[] = {
 					.buswidth = 8,
 					.backlight = 1,
 				},
-				.startbyte = 0b01110000,
+				.startbyte = 0x70,
 				.bgr = true,
 				.gpios = (const struct fbtft_gpio []) {
 					{ "reset", 25 },
@@ -484,9 +623,9 @@ static struct fbtft_device_display displays[] = {
 					.backlight = 1,
 					.init_sequence = hy28b_init_sequence,
 				},
-				.startbyte = 0b01110000,
+				.startbyte = 0x70,
 				.bgr = true,
-				.fps= 50,
+				.fps = 50,
 				.gpios = (const struct fbtft_gpio []) {
 					{ "reset", 25 },
 					{ "led", 18 },
@@ -532,8 +671,8 @@ static struct fbtft_device_display displays[] = {
 				.gpios = (const struct fbtft_gpio []) {
 					/* Wiring for LCD adapter kit */
 					{ "reset", 7 },
-					{ "dc", 0 }, 	/* rev 2: 2 */
-					{ "wr", 1 }, 	/* rev 2: 3 */
+					{ "dc", 0 },	/* rev 2: 2 */
+					{ "wr", 1 },	/* rev 2: 3 */
 					{ "cs", 8 },
 					{ "db00", 17 },
 					{ "db01", 18 },
@@ -597,7 +736,7 @@ static struct fbtft_device_display displays[] = {
 					.buswidth = 8,
 					.backlight = 1,
 				},
-				.startbyte = 0b01110000,
+				.startbyte = 0x70,
 				.bgr = true,
 				.gpios = (const struct fbtft_gpio []) {
 					{ "reset", 25 },
@@ -676,6 +815,24 @@ static struct fbtft_device_display displays[] = {
 			}
 		}
 	}, {
+		.name = "nokia5110",
+		.spi = &(struct spi_board_info) {
+			.modalias = "fb_ili9163",
+			.max_speed_hz = 12000000,
+			.mode = SPI_MODE_0,
+			.platform_data = &(struct fbtft_platform_data) {
+				.display = {
+					.buswidth = 8,
+					.backlight = 1,
+				},
+				.bgr = true,
+				.gpios = (const struct fbtft_gpio []) {
+					{},
+				},
+			}
+		}
+	}, {
+
 		.name = "piscreen",
 		.spi = &(struct spi_board_info) {
 			.modalias = "fb_ili9486",
@@ -732,13 +889,13 @@ static struct fbtft_device_display displays[] = {
 					{ "dc", 25 },
 					{},
 				},
-				.gamma =	"0 2 2 2 2 2 2 2 " \
-						"2 2 2 2 2 2 2 2 " \
-						"2 2 2 2 2 2 2 2 " \
-						"2 2 2 2 2 2 2 3 " \
-						"3 3 3 3 3 3 3 3 " \
-						"3 3 3 3 3 3 3 3 " \
-						"3 3 3 4 4 4 4 4 " \
+				.gamma =	"0 2 2 2 2 2 2 2 "
+						"2 2 2 2 2 2 2 2 "
+						"2 2 2 2 2 2 2 2 "
+						"2 2 2 2 2 2 2 3 "
+						"3 3 3 3 3 3 3 3 "
+						"3 3 3 3 3 3 3 3 "
+						"3 3 3 4 4 4 4 4 "
 						"4 4 4 4 4 4 4"
 			}
 		}
@@ -852,7 +1009,7 @@ static struct fbtft_device_display displays[] = {
 					.buswidth = 16,
 					.txbuflen = -2, /* disable buffer */
 					.backlight = 1,
-					.fbtftops.write = \
+					.fbtftops.write =
 						fbtft_write_gpio16_wr_latched,
 				},
 				.bgr = true,
@@ -1019,7 +1176,8 @@ static struct fbtft_device_display displays[] = {
 				.display = {
 					.buswidth = 8,
 					.backlight = 1,
-					.init_sequence = waveshare32b_init_sequence,
+					.init_sequence =
+						waveshare32b_init_sequence,
 				},
 				.bgr = true,
 				.gpios = (const struct fbtft_gpio []) {
@@ -1100,14 +1258,14 @@ static int write_gpio16_wr_slow(struct fbtft_par *par, void *buf, size_t len)
 			for (i = 0; i < 16; i++) {
 				if ((data & 1) != (prev_data & 1))
 					gpio_set_value(par->gpio.db[i],
-								(data & 1));
+								data & 1);
 				data >>= 1;
 				prev_data >>= 1;
 			}
 		}
 #else
 		for (i = 0; i < 16; i++) {
-			gpio_set_value(par->gpio.db[i], (data & 1));
+			gpio_set_value(par->gpio.db[i], data & 1);
 			data >>= 1;
 		}
 #endif
@@ -1128,15 +1286,13 @@ static int write_gpio16_wr_slow(struct fbtft_par *par, void *buf, size_t len)
 static void adafruit18_green_tab_set_addr_win(struct fbtft_par *par,
 						int xs, int ys, int xe, int ye)
 {
-	fbtft_par_dbg(DEBUG_SET_ADDR_WIN, par,
-		"%s(xs=%d, ys=%d, xe=%d, ye=%d)\n", __func__, xs, ys, xe, ye);
 	write_reg(par, 0x2A, 0, xs + 2, 0, xe + 2);
 	write_reg(par, 0x2B, 0, ys + 1, 0, ye + 1);
 	write_reg(par, 0x2C);
 }
 
 /* used if gpios parameter is present */
-static struct fbtft_gpio fbtft_device_param_gpios[MAX_GPIOS+1] = { };
+static struct fbtft_gpio fbtft_device_param_gpios[MAX_GPIOS + 1] = { };
 
 static void fbtft_device_pdev_release(struct device *dev)
 {
@@ -1149,16 +1305,16 @@ static int spi_device_found(struct device *dev, void *data)
 {
 	struct spi_device *spi = container_of(dev, struct spi_device, dev);
 
-	pr_info(DRVNAME":      %s %s %dkHz %d bits mode=0x%02X\n",
-		spi->modalias, dev_name(dev), spi->max_speed_hz/1000,
-		spi->bits_per_word, spi->mode);
+	dev_info(dev, "%s %s %dkHz %d bits mode=0x%02X\n", spi->modalias,
+		 dev_name(dev), spi->max_speed_hz / 1000, spi->bits_per_word,
+		 spi->mode);
 
 	return 0;
 }
 
 static void pr_spi_devices(void)
 {
-	pr_info(DRVNAME":  SPI devices registered:\n");
+	pr_debug("SPI devices registered:\n");
 	bus_for_each_dev(&spi_bus_type, NULL, NULL, spi_device_found);
 }
 
@@ -1168,16 +1324,15 @@ static int p_device_found(struct device *dev, void *data)
 	*pdev = container_of(dev, struct platform_device, dev);
 
 	if (strstr(pdev->name, "fb"))
-		pr_info(DRVNAME":      %s id=%d pdata? %s\n",
-				pdev->name, pdev->id,
-				pdev->dev.platform_data ? "yes" : "no");
+		dev_info(dev, "%s id=%d pdata? %s\n", pdev->name, pdev->id,
+			 pdev->dev.platform_data ? "yes" : "no");
 
 	return 0;
 }
 
 static void pr_p_devices(void)
 {
-	pr_info(DRVNAME":  'fb' Platform devices registered:\n");
+	pr_debug("'fb' Platform devices registered:\n");
 	bus_for_each_dev(&platform_bus_type, NULL, NULL, p_device_found);
 }
 
@@ -1192,7 +1347,7 @@ static void fbtft_device_spi_delete(struct spi_master *master, unsigned cs)
 	dev = bus_find_device_by_name(&spi_bus_type, NULL, str);
 	if (dev) {
 		if (verbose)
-			pr_info(DRVNAME": Deleting %s\n", str);
+			dev_info(dev, "Deleting %s\n", str);
 		device_del(dev);
 	}
 }
@@ -1203,8 +1358,8 @@ static int fbtft_device_spi_device_register(struct spi_board_info *spi)
 
 	master = spi_busnum_to_master(spi->bus_num);
 	if (!master) {
-		pr_err(DRVNAME ":  spi_busnum_to_master(%d) returned NULL\n",
-								spi->bus_num);
+		pr_err("spi_busnum_to_master(%d) returned NULL\n",
+		       spi->bus_num);
 		return -EINVAL;
 	}
 	/* make sure it's available */
@@ -1212,7 +1367,7 @@ static int fbtft_device_spi_device_register(struct spi_board_info *spi)
 	spi_device = spi_new_device(master, spi);
 	put_device(&master->dev);
 	if (!spi_device) {
-		pr_err(DRVNAME ":    spi_new_device() returned NULL\n");
+		dev_err(&master->dev, "spi_new_device() returned NULL\n");
 		return -EPERM;
 	}
 	return 0;
@@ -1235,11 +1390,9 @@ static int __init fbtft_device_init(void)
 	long val;
 	int ret = 0;
 
-	pr_debug("\n\n"DRVNAME": init\n");
-
 	if (name == NULL) {
 #ifdef MODULE
-		pr_err(DRVNAME":  missing module parameter: 'name'\n");
+		pr_err("missing module parameter: 'name'\n");
 		return -EINVAL;
 #else
 		return 0;
@@ -1247,41 +1400,37 @@ static int __init fbtft_device_init(void)
 	}
 
 	if (init_num > FBTFT_MAX_INIT_SEQUENCE) {
-		pr_err(DRVNAME \
-			":  init parameter: exceeded max array size: %d\n",
-			FBTFT_MAX_INIT_SEQUENCE);
+		pr_err("init parameter: exceeded max array size: %d\n",
+		       FBTFT_MAX_INIT_SEQUENCE);
 		return -EINVAL;
 	}
 
 	/* parse module parameter: gpios */
 	while ((p_gpio = strsep(&gpios, ","))) {
 		if (strchr(p_gpio, ':') == NULL) {
-			pr_err(DRVNAME \
-				":  error: missing ':' in gpios parameter: %s\n",
-				p_gpio);
+			pr_err("error: missing ':' in gpios parameter: %s\n",
+			       p_gpio);
 			return -EINVAL;
 		}
 		p_num = p_gpio;
 		p_name = strsep(&p_num, ":");
 		if (p_name == NULL || p_num == NULL) {
-			pr_err(DRVNAME \
-				":  something bad happened parsing gpios parameter: %s\n",
-				p_gpio);
+			pr_err("something bad happened parsing gpios parameter: %s\n",
+			       p_gpio);
 			return -EINVAL;
 		}
 		ret = kstrtol(p_num, 10, &val);
 		if (ret) {
-			pr_err(DRVNAME \
-				":  could not parse number in gpios parameter: %s:%s\n",
-				p_name, p_num);
+			pr_err("could not parse number in gpios parameter: %s:%s\n",
+			       p_name, p_num);
 			return -EINVAL;
 		}
-		strcpy(fbtft_device_param_gpios[i].name, p_name);
+		strncpy(fbtft_device_param_gpios[i].name, p_name,
+			FBTFT_GPIO_NAME_SIZE - 1);
 		fbtft_device_param_gpios[i++].gpio = (int) val;
 		if (i == MAX_GPIOS) {
-			pr_err(DRVNAME \
-				":  gpios parameter: exceeded max array size: %d\n",
-				MAX_GPIOS);
+			pr_err("gpios parameter: exceeded max array size: %d\n",
+			       MAX_GPIOS);
 			return -EINVAL;
 		}
 	}
@@ -1294,7 +1443,7 @@ static int __init fbtft_device_init(void)
 	if (verbose > 2)
 		pr_p_devices(); /* print list of 'fb' platform devices */
 
-	pr_debug(DRVNAME":  name='%s', busnum=%d, cs=%d\n", name, busnum, cs);
+	pr_debug("name='%s', busnum=%d, cs=%d\n", name, busnum, cs);
 
 	if (rotate > 0 && rotate < 4) {
 		rotate = (4 - rotate) * 90;
@@ -1308,11 +1457,11 @@ static int __init fbtft_device_init(void)
 	}
 
 	/* name=list lists all supported displays */
-	if (strncmp(name, "list", 32) == 0) {
-		pr_info(DRVNAME":  Supported displays:\n");
+	if (strncmp(name, "list", FBTFT_GPIO_NAME_SIZE) == 0) {
+		pr_info("Supported displays:\n");
 
 		for (i = 0; i < ARRAY_SIZE(displays); i++)
-			pr_info(DRVNAME":      %s\n", displays[i].name);
+			pr_info("%s\n", displays[i].name);
 		return -ECANCELED;
 	}
 
@@ -1343,7 +1492,7 @@ static int __init fbtft_device_init(void)
 				p_device = displays[i].pdev;
 				pdata = p_device->dev.platform_data;
 			} else {
-				pr_err(DRVNAME": broken displays array\n");
+				pr_err("broken displays array\n");
 				return -EINVAL;
 			}
 
@@ -1375,43 +1524,38 @@ static int __init fbtft_device_init(void)
 			if (displays[i].spi) {
 				ret = fbtft_device_spi_device_register(spi);
 				if (ret) {
-					pr_err(DRVNAME \
-						": failed to register SPI device\n");
+					pr_err("failed to register SPI device\n");
 					return ret;
 				}
-				found = true;
-				break;
 			} else {
 				ret = platform_device_register(p_device);
 				if (ret < 0) {
-					pr_err(DRVNAME \
-						":    platform_device_register() returned %d\n",
-						ret);
+					pr_err("platform_device_register() returned %d\n",
+					       ret);
 					return ret;
 				}
-				found = true;
-				break;
 			}
+			found = true;
+			break;
 		}
 	}
 
 	if (!found) {
-		pr_err(DRVNAME":  display not supported: '%s'\n", name);
+		pr_err("display not supported: '%s'\n", name);
 		return -EINVAL;
 	}
 
 	if (verbose && pdata && pdata->gpios) {
 		gpio = pdata->gpios;
-		pr_info(DRVNAME":  GPIOS used by '%s':\n", name);
+		pr_info("GPIOS used by '%s':\n", name);
 		found = false;
 		while (verbose && gpio->name[0]) {
-			pr_info(DRVNAME":    '%s' = GPIO%d\n",
-				gpio->name, gpio->gpio);
+			pr_info("'%s' = GPIO%d\n", gpio->name, gpio->gpio);
 			gpio++;
 			found = true;
 		}
 		if (!found)
-			pr_info(DRVNAME":    (none)\n");
+			pr_info("(none)\n");
 	}
 
 	if (spi_device && (verbose > 1))
@@ -1424,8 +1568,6 @@ static int __init fbtft_device_init(void)
 
 static void __exit fbtft_device_exit(void)
 {
-	pr_debug(DRVNAME" - exit\n");
-
 	if (spi_device) {
 		device_del(&spi_device->dev);
 		kfree(spi_device);


### PR DESCRIPTION
Linux framebuffer should be setup for 40x240, 1 bpp.  Driver code (elsewhere) must deal with turning the 320x240 data
into 40x240 and write it to the framebuffer device (this packs all 320 bits into 40 bytes, 320/8 = 40).  This driver then translates 40x240 data into the commands needed for the display.