### PR TITLE
fix: Compilation errors with kernel ~5.1+ fixed.

### DIFF
--- a/fbtft.h
+++ b/fbtft.h
@@ -251,7 +251,7 @@ struct fbtft_par {
 	} gamma;
 	unsigned long debug;
 	bool first_update_done;
-	struct timespec update_time;
+	struct timespec64 update_time;
 	bool bgr;
 	void *extra;
 };


### PR DESCRIPTION
- `timespec` replaced with `timespec64`
- `getnstimeofday` replaced with `ktime_get_real_ts64`
- return type of `unregister_framebuffer` from linux/fb.h changed from `int` to `void`